### PR TITLE
Add MSTest project with Gaul buySoldier failing test

### DIFF
--- a/MedievalEmpires.Tests/GaulTests.cs
+++ b/MedievalEmpires.Tests/GaulTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MedievalEmpires;
+
+namespace MedievalEmpires.Tests
+{
+    [TestClass]
+    public class GaulTests
+    {
+        [TestMethod]
+        public void BuySoldier_WithTooFewCoins_ThrowsExceptionAndCoinsUnchanged()
+        {
+            // Arrange
+            var gaul = new Gaul("TestGaul", 0, 10);
+            var soldier = new Knight("Weak", 0, 0, 20, gaul);
+            var initialCoins = gaul.pCoins;
+
+            // Act & Assert
+            Assert.ThrowsException<Exception>(() => gaul.buySoldier(soldier));
+            Assert.AreEqual(initialCoins, gaul.pCoins, "Coins should remain unchanged when purchase fails");
+        }
+    }
+}

--- a/MedievalEmpires.Tests/MedievalEmpires.Tests.csproj
+++ b/MedievalEmpires.Tests/MedievalEmpires.Tests.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{ABBF9835-66DA-41CE-9EDD-717E58BF77C9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MedievalEmpires.Tests</RootNamespace>
+    <AssemblyName>MedievalEmpires.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MedievalEmpires\MedievalEmpires.vbproj">
+      <Project>{CD8E53D2-B177-494B-AE08-1CEEF98E43D7}</Project>
+      <Name>MedievalEmpires</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GaulTests.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/MedievalEmpires.sln
+++ b/MedievalEmpires.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "MedievalEmpires", "MedievalEmpires\MedievalEmpires.vbproj", "{CD8E53D2-B177-494B-AE08-1CEEF98E43D7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MedievalEmpires.Tests", "MedievalEmpires.Tests\MedievalEmpires.Tests.csproj", "{ABBF9835-66DA-41CE-9EDD-717E58BF77C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,9 +15,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CD8E53D2-B177-494B-AE08-1CEEF98E43D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CD8E53D2-B177-494B-AE08-1CEEF98E43D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CD8E53D2-B177-494B-AE08-1CEEF98E43D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CD8E53D2-B177-494B-AE08-1CEEF98E43D7}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {CD8E53D2-B177-494B-AE08-1CEEF98E43D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CD8E53D2-B177-494B-AE08-1CEEF98E43D7}.Release|Any CPU.Build.0 = Release|Any CPU
+                {ABBF9835-66DA-41CE-9EDD-717E58BF77C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {ABBF9835-66DA-41CE-9EDD-717E58BF77C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {ABBF9835-66DA-41CE-9EDD-717E58BF77C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {ABBF9835-66DA-41CE-9EDD-717E58BF77C9}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add MSTest project `MedievalEmpires.Tests`
- implement `GaulTests` verifying exception and coin balance when buying with insufficient gold
- reference new test project from the solution

## Testing
- `dotnet test MedievalEmpires.Tests/MedievalEmpires.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff3e347b48322ae5776f301fd50bb